### PR TITLE
Feature/3 explore

### DIFF
--- a/lib/core/models/paper_model.dart
+++ b/lib/core/models/paper_model.dart
@@ -15,6 +15,18 @@ class Paper {
     required this.imageUrl,
   });
 
+  // JSON 변환 메소드
+  factory Paper.fromJson(Map<String, dynamic> json) {
+    return Paper(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      summary: json['summary'] as String,
+      tags: List<String>.from(json['tags'] ?? []),
+      recommendationReason: json['recommendationReason'] as String? ?? '',
+      imageUrl: json['imageUrl'] as String? ?? '',
+    );
+  }
+
   ///샘플 데이터 반환
   static List<Paper> sampleList() {
     return [

--- a/lib/features/dashboard/viewmodel/dashboard_viewmodel.dart
+++ b/lib/features/dashboard/viewmodel/dashboard_viewmodel.dart
@@ -14,6 +14,9 @@ class MainViewModel extends ChangeNotifier {
   /// 현재 선택된 페이지
   PageType currentPage = PageType.home;
 
+  String _searchQuery = '';
+  String get searchQuery => _searchQuery;
+
   MainViewModel() {
     _loadInitialData();
     _loadRecommendedPapers();
@@ -47,5 +50,12 @@ class MainViewModel extends ChangeNotifier {
   void navigationTo(PageType page) {
     currentPage = page;
     notifyListeners();
+  }
+
+  void setSearchQuery(String q) {
+    if (_searchQuery != q) {
+      _searchQuery = q;
+      notifyListeners();
+    }
   }
 }

--- a/lib/features/dashboard/widgets/header_widget.dart
+++ b/lib/features/dashboard/widgets/header_widget.dart
@@ -72,7 +72,10 @@ class HeaderWidget extends StatelessWidget {
           _NavItem(
             label: 'Explore',
             selected: vm.currentPage == PageType.explore,
-            onTap: () => vm.navigationTo(PageType.explore),
+            onTap: () {
+              vm.navigationTo(PageType.explore);
+              Navigator.of(context).pushNamed('/explore');
+            },
           ),
           _NavItem(
             label: 'My Library',

--- a/lib/features/dashboard/widgets/header_widget.dart
+++ b/lib/features/dashboard/widgets/header_widget.dart
@@ -5,11 +5,31 @@ import '../../../shared/theme/theme_provider.dart';
 import 'notification_icon.dart';
 import '../../profile/widgets/avatar_menu.dart';
 
-class HeaderWidget extends StatelessWidget {
+class HeaderWidget extends StatefulWidget {
   const HeaderWidget({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  _HeaderWidgetState createState() => _HeaderWidgetState();
+}
+
+class _HeaderWidgetState extends State<HeaderWidget> {
+  late final TextEditingController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    final vm = context.read<MainViewModel>();
+    _ctrl = TextEditingController(text: vm.searchQuery);
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  build(BuildContext context) {
     final isLight = context.watch<ThemeProvider>().mode == ThemeMode.light;
     final vm = context.watch<MainViewModel>();
     return Container(
@@ -94,6 +114,7 @@ class HeaderWidget extends StatelessWidget {
           SizedBox(
             width: 200,
             child: TextField(
+              controller: _ctrl,
               decoration: InputDecoration(
                 contentPadding: const EdgeInsets.symmetric(
                   horizontal: 12,
@@ -112,8 +133,13 @@ class HeaderWidget extends StatelessWidget {
                 ),
               ),
               style: const TextStyle(color: Colors.white),
+              textInputAction: TextInputAction.search,
+              onChanged: vm.setSearchQuery,
               onSubmitted: (q) {
-                //TODO: 검색 기능 구현
+                final query = q.trim();
+                if (query.isNotEmpty) {
+                  Navigator.of(context).pushNamed('/explore', arguments: query);
+                }
               },
             ),
           ),

--- a/lib/features/explore/service/arxiv_service.dart
+++ b/lib/features/explore/service/arxiv_service.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../../../core/models/paper_model.dart';
+
+class ArxivService {
+  // 프록시 서버 엔드 포인트
+  final _endpoint = 'https://your-proxy-server.com/api/arxiv';
+
+  Future<List<Paper>> fetchPapers(String query) async {
+    final url = Uri.parse(
+      '$_endpoint?query=$query=${Uri.encodeQueryComponent(query)}',
+    );
+    final response = await http.get(url);
+
+    if (response.statusCode == 200) {
+      final List<dynamic> data = json.decode(response.body) as List<dynamic>;
+      return data
+          .map((json) => Paper.fromJson(json as Map<String, dynamic>))
+          .toList();
+    } else {
+      throw Exception('Failed to load papers : ${response.statusCode}');
+    }
+  }
+}

--- a/lib/features/explore/view/explore_page.dart
+++ b/lib/features/explore/view/explore_page.dart
@@ -5,6 +5,8 @@ import '../widgets/paper_card.dart';
 import '../../dashboard/widgets/header_widget.dart';
 import '../../dashboard/widgets/sidebar_widget.dart';
 import '../../dashboard/viewmodel/dashboard_viewmodel.dart';
+import '../../dashboard/widgets/recommend_paper_card.dart';
+import '../../../core/models/paper_model.dart';
 
 class ExplorePage extends StatefulWidget {
   final String initialQuery;
@@ -34,78 +36,124 @@ class _ExplorePageState extends State<ExplorePage> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => ExploreViewmodel(),
-      child: Scaffold(
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        appBar: PreferredSize(
-          preferredSize: const Size.fromHeight(80),
-          child: HeaderWidget(),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              if (context.watch<MainViewModel>().isSidebarOpen) SidebarWidget(),
-              VerticalDivider(
-                width: 1,
-                thickness: 1,
-                color: Theme.of(context).dividerColor,
-              ),
-              Expanded(
-                child: Column(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: TextField(
-                        controller: _searchController,
-                        decoration: InputDecoration(
-                          hintText: '논문을 검색해 보세요',
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          suffixIcon: const Icon(Icons.search),
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(80),
+        child: HeaderWidget(),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (context.watch<MainViewModel>().isSidebarOpen) SidebarWidget(),
+            VerticalDivider(
+              width: 1,
+              thickness: 1,
+              color: Theme.of(context).dividerColor,
+            ),
+            Expanded(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: TextField(
+                      controller: _searchController,
+                      decoration: InputDecoration(
+                        hintText: '논문을 검색해 보세요',
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
                         ),
-                        textInputAction: TextInputAction.search,
-                        onSubmitted: (q) {
-                          final query = q.trim();
-                          context.read<ExploreViewmodel>().search(query);
-                        },
+                        suffixIcon: const Icon(Icons.search),
                       ),
+                      textInputAction: TextInputAction.search,
+                      onSubmitted: (q) {
+                        final query = q.trim();
+                        context.read<ExploreViewmodel>().search(query);
+                      },
                     ),
-                    Expanded(
-                      child: Consumer<ExploreViewmodel>(
-                        builder: (contxt, vm, _) {
-                          if (vm.isLoading) {
-                            return const Center(
-                              child: CircularProgressIndicator(),
-                            );
-                          }
-
-                          if (vm.errorMessage != null) {
-                            return Center(
-                              child: Text('오류 발생: ${vm.errorMessage}'),
-                            );
-                          }
-
-                          if (vm.papers.isEmpty) {
-                            return const Center(child: Text('검색 결과가 없습니다.'));
-                          }
-
+                  ),
+                  Expanded(
+                    child: Consumer<ExploreViewmodel>(
+                      builder: (_, vm, __) {
+                        if (!vm.hasSearched) {
+                          final recs = Paper.sampleList();
                           return ListView.builder(
-                            itemCount: vm.papers.length,
-                            itemBuilder: (_, index) =>
-                                PaperCard(paper: vm.papers[index]),
+                            padding: const EdgeInsets.all(16),
+                            itemCount: recs.length,
+                            itemBuilder: (_, i) =>
+                                RecommendPaperCard(paper: recs[i]),
                           );
-                        },
-                      ),
+                        }
+                        if (vm.isLoading) {
+                          return const Center(
+                            child: CircularProgressIndicator(),
+                          );
+                        }
+
+                        if (vm.errorMessage != null) {
+                          final recs = Paper.sampleList();
+                          return Column(
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Text('검색에 실패했습니다.'),
+                              ),
+                              const Divider(),
+                              const Padding(
+                                padding: EdgeInsets.symmetric(vertical: 8),
+                                child: Text('이런 논문은 어떠세요?'),
+                              ),
+                              Expanded(
+                                child: ListView.builder(
+                                  padding: const EdgeInsets.all(16),
+                                  itemCount: recs.length,
+                                  itemBuilder: (_, i) =>
+                                      RecommendPaperCard(paper: recs[i]),
+                                ),
+                              ),
+                            ],
+                          );
+                        }
+
+                        if (vm.papers.isEmpty) {
+                          final recs = Paper.sampleList();
+                          return Column(
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Text('검색 결과가 없습니다.'),
+                              ),
+                              const Divider(),
+                              const Padding(
+                                padding: EdgeInsets.symmetric(vertical: 8),
+                                child: Text('이런 논문은 어떠세요?'),
+                              ),
+                              Expanded(
+                                child: ListView.builder(
+                                  padding: const EdgeInsets.all(16),
+                                  itemCount: recs.length,
+                                  itemBuilder: (_, i) =>
+                                      RecommendPaperCard(paper: recs[i]),
+                                ),
+                              ),
+                            ],
+                          );
+                        }
+
+                        return ListView.builder(
+                          itemCount: vm.papers.length,
+                          itemBuilder: (_, index) =>
+                              PaperCard(paper: vm.papers[index]),
+                        );
+                      },
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/explore/view/explore_page.dart
+++ b/lib/features/explore/view/explore_page.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../viewmodel/explore_viewmodel.dart';
 import '../widgets/paper_card.dart';
+import '../../dashboard/widgets/header_widget.dart';
+import '../../dashboard/widgets/sidebar_widget.dart';
+import '../../dashboard/viewmodel/dashboard_viewmodel.dart';
 
 class ExplorePage extends StatelessWidget {
   const ExplorePage({Key? key}) : super(key: key);
@@ -14,47 +17,71 @@ class ExplorePage extends StatelessWidget {
     return ChangeNotifierProvider(
       create: (_) => ExploreViewmodel()..search(initialQuery ?? ''),
       child: Scaffold(
-        appBar: AppBar(title: const Text('Explore Papers'), centerTitle: true),
-        body: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: TextField(
-                decoration: InputDecoration(
-                  hintText: '논문을 검색해 보세요',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  suffixIcon: const Icon(Icons.search),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(80),
+          child: HeaderWidget(),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (context.watch<MainViewModel>().isSidebarOpen) SidebarWidget(),
+              VerticalDivider(
+                width: 1,
+                thickness: 1,
+                color: Theme.of(context).dividerColor,
+              ),
+              Expanded(
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: TextField(
+                        decoration: InputDecoration(
+                          hintText: '논문을 검색해 보세요',
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          suffixIcon: const Icon(Icons.search),
+                        ),
+                        textInputAction: TextInputAction.search,
+                        onSubmitted: context.read<ExploreViewmodel>().search,
+                      ),
+                    ),
+                    Expanded(
+                      child: Consumer<ExploreViewmodel>(
+                        builder: (contxt, vm, _) {
+                          if (vm.isLoading) {
+                            return const Center(
+                              child: CircularProgressIndicator(),
+                            );
+                          }
+
+                          if (vm.errorMessage != null) {
+                            return Center(
+                              child: Text('오류 발생: ${vm.errorMessage}'),
+                            );
+                          }
+
+                          if (vm.papers.isEmpty) {
+                            return const Center(child: Text('검색 결과가 없습니다.'));
+                          }
+
+                          return ListView.builder(
+                            itemCount: vm.papers.length,
+                            itemBuilder: (_, index) =>
+                                PaperCard(paper: vm.papers[index]),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
                 ),
-                textInputAction: TextInputAction.search,
-                onSubmitted: context.read<ExploreViewmodel>().search,
               ),
-            ),
-            Expanded(
-              child: Consumer<ExploreViewmodel>(
-                builder: (contxt, vm, _) {
-                  if (vm.isLoading) {
-                    return const Center(child: CircularProgressIndicator());
-                  }
-
-                  if (vm.errorMessage != null) {
-                    return Center(child: Text('오류 발생: ${vm.errorMessage}'));
-                  }
-
-                  if (vm.papers.isEmpty) {
-                    return const Center(child: Text('검색 결과가 없습니다.'));
-                  }
-
-                  return ListView.builder(
-                    itemCount: vm.papers.length,
-                    itemBuilder: (_, index) =>
-                        PaperCard(paper: vm.papers[index]),
-                  );
-                },
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/explore/view/explore_page.dart
+++ b/lib/features/explore/view/explore_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../viewmodel/explore_viewmodel.dart';
+import '../widgets/paper_card.dart';
+
+class ExplorePage extends StatelessWidget {
+  const ExplorePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final initialQuery =
+        ModalRoute.of(context)?.settings.arguments as String? ?? '';
+
+    return ChangeNotifierProvider(
+      create: (_) => ExploreViewmodel()..search(initialQuery ?? ''),
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Explore Papers'), centerTitle: true),
+        body: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: TextField(
+                decoration: InputDecoration(
+                  hintText: '논문을 검색해 보세요',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  suffixIcon: const Icon(Icons.search),
+                ),
+                textInputAction: TextInputAction.search,
+                onSubmitted: context.read<ExploreViewmodel>().search,
+              ),
+            ),
+            Expanded(
+              child: Consumer<ExploreViewmodel>(
+                builder: (contxt, vm, _) {
+                  if (vm.isLoading) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (vm.errorMessage != null) {
+                    return Center(child: Text('오류 발생: ${vm.errorMessage}'));
+                  }
+
+                  if (vm.papers.isEmpty) {
+                    return const Center(child: Text('검색 결과가 없습니다.'));
+                  }
+
+                  return ListView.builder(
+                    itemCount: vm.papers.length,
+                    itemBuilder: (_, index) =>
+                        PaperCard(paper: vm.papers[index]),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/explore/view/explore_page.dart
+++ b/lib/features/explore/view/explore_page.dart
@@ -6,16 +6,36 @@ import '../../dashboard/widgets/header_widget.dart';
 import '../../dashboard/widgets/sidebar_widget.dart';
 import '../../dashboard/viewmodel/dashboard_viewmodel.dart';
 
-class ExplorePage extends StatelessWidget {
-  const ExplorePage({Key? key}) : super(key: key);
+class ExplorePage extends StatefulWidget {
+  final String initialQuery;
+  const ExplorePage({Key? key, required this.initialQuery}) : super(key: key);
+
+  @override
+  _ExplorePageState createState() => _ExplorePageState();
+}
+
+class _ExplorePageState extends State<ExplorePage> {
+  late final TextEditingController _searchController;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController = TextEditingController(text: widget.initialQuery);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<ExploreViewmodel>().search(widget.initialQuery);
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final initialQuery =
-        ModalRoute.of(context)?.settings.arguments as String? ?? '';
-
     return ChangeNotifierProvider(
-      create: (_) => ExploreViewmodel()..search(initialQuery ?? ''),
+      create: (_) => ExploreViewmodel(),
       child: Scaffold(
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         appBar: PreferredSize(
@@ -39,6 +59,7 @@ class ExplorePage extends StatelessWidget {
                     Padding(
                       padding: const EdgeInsets.all(16),
                       child: TextField(
+                        controller: _searchController,
                         decoration: InputDecoration(
                           hintText: '논문을 검색해 보세요',
                           border: OutlineInputBorder(
@@ -47,7 +68,10 @@ class ExplorePage extends StatelessWidget {
                           suffixIcon: const Icon(Icons.search),
                         ),
                         textInputAction: TextInputAction.search,
-                        onSubmitted: context.read<ExploreViewmodel>().search,
+                        onSubmitted: (q) {
+                          final query = q.trim();
+                          context.read<ExploreViewmodel>().search(query);
+                        },
                       ),
                     ),
                     Expanded(

--- a/lib/features/explore/viewmodel/explore_viewmodel.dart
+++ b/lib/features/explore/viewmodel/explore_viewmodel.dart
@@ -8,8 +8,11 @@ class ExploreViewmodel extends ChangeNotifier {
   bool isLoading = false;
   String? errorMessage;
   List<Paper> papers = [];
+  bool hasSearched = false;
 
   Future<void> search(String query) async {
+    hasSearched = true;
+    notifyListeners();
     if (query.trim().isEmpty) return;
     isLoading = true;
     errorMessage = null;

--- a/lib/features/explore/viewmodel/explore_viewmodel.dart
+++ b/lib/features/explore/viewmodel/explore_viewmodel.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import '../../../core/models/paper_model.dart';
+import '../service/arxiv_service.dart';
+
+class ExploreViewmodel extends ChangeNotifier {
+  final _service = ArxivService();
+
+  bool isLoading = false;
+  String? errorMessage;
+  List<Paper> papers = [];
+
+  Future<void> search(String query) async {
+    if (query.trim().isEmpty) return;
+    isLoading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      papers = await _service.fetchPapers(query);
+    } catch (e) {
+      errorMessage = e.toString();
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/explore/widgets/paper_card.dart
+++ b/lib/features/explore/widgets/paper_card.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import '../../../core/models/paper_model.dart';
+
+class PaperCard extends StatelessWidget {
+  final Paper paper;
+  const PaperCard({required this.paper, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadiusGeometry.circular(8),
+      ),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              paper.title,
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(paper.summary, maxLines: 3, overflow: TextOverflow.ellipsis),
+            if (paper.tags.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                children: paper.tags
+                    .map(
+                      (tag) => Chip(
+                        label: Text(tag, style: TextStyle(fontSize: 12)),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+            if (paper.recommendationReason.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                '추천 이유: ${paper.recommendationReason}',
+                style: Theme.of(context).textTheme.labelSmall,
+              ),
+            ],
+            if (paper.imageUrl.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: Image.network(
+                  paper.imageUrl,
+                  height: 100,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,7 @@ class PaperLogApp extends StatelessWidget {
               ModalRoute.of(context)!.settings.arguments as String? ?? '';
           return ChangeNotifierProvider<ExploreViewmodel>(
             create: (_) => ExploreViewmodel()..search(initialQuery),
-            child: const ExplorePage(),
+            child: ExplorePage(initialQuery: initialQuery),
           );
         },
         //'/login': (context) => LoginPage(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:paperlog_front/features/explore/view/explore_page.dart';
+import 'package:paperlog_front/features/explore/viewmodel/explore_viewmodel.dart';
 import 'package:provider/provider.dart';
 import 'features/dashboard/view/main_screen.dart';
 import 'shared/theme/app_theme.dart';
@@ -42,6 +44,14 @@ class PaperLogApp extends StatelessWidget {
       routes: {
         '/': (_) => const MainScreen(),
         '/profile': (_) => ProfilePage(),
+        '/explore': (context) {
+          final initialQuery =
+              ModalRoute.of(context)!.settings.arguments as String? ?? '';
+          return ChangeNotifierProvider<ExploreViewmodel>(
+            create: (_) => ExploreViewmodel()..search(initialQuery),
+            child: const ExplorePage(),
+          );
+        },
         //'/login': (context) => LoginPage(),
         //'/settings': (context) => SettingsPage(),
       },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.6"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -208,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.0.5
+  http: ^0.13.5
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## 🔍 Key Changes

1. **MVVM Folder Structure**

   * Reuse existing `core/models/paper_model.dart` for `Paper` model
   * `features/explore/service/arxiv_service.dart`: handles HTTP calls to your backend’s arXiv proxy
   * `features/explore/viewmodel/explore_viewmodel.dart`: manages search logic, loading/error flags, and a `hasSearched` flag
   * `features/explore/view/explore_page.dart`: converted to `StatefulWidget`, accepts `initialQuery`, binds a `TextEditingController`, and renders UI states
   * `features/explore/widgets/paper_card.dart`: displays individual paper results
   * `features/dashboard/widgets/recommend_paper_card.dart`: reused for “recommended” cards on initial, empty-result, or error screens

2. **Header Search Integration**

   * `HeaderWidget` now uses a `TextEditingController` and `onSubmitted` to navigate to `/explore` with the entered query
   * `MainViewModel` stores the latest search term so the header’s search field retains its value across navigation

3. **Explore Page UI Flow**

   * **Initial Load** (`hasSearched == false`): show three recommended papers
   * **Loading**: display a centered `CircularProgressIndicator`
   * **Error**: show “Search failed” + “How about these papers?” + recommended list
   * **No Results**: show “No results found” + “How about these papers?” + recommended list
   * **Success**: render actual results via `PaperCard`

4. **Routing & Provider Setup**

   * In `main.dart`, the `/explore` route is wrapped with `ChangeNotifierProvider<ExploreViewmodel>` and passes `initialQuery`
   * Removed duplicate providers so there’s only one `ExploreViewmodel` instance per navigation


