### PR TITLE
feat(paper): make paper page

### DIFF
--- a/lib/core/models/paper_detail_model.dart
+++ b/lib/core/models/paper_detail_model.dart
@@ -1,0 +1,67 @@
+class BlogPost {
+  final String title;
+  final String excerpt;
+  final String url;
+  final String? imageUrl;
+
+  BlogPost({
+    required this.title,
+    required this.excerpt,
+    required this.url,
+    required this.imageUrl,
+  });
+
+  factory BlogPost.fromJson(Map<String, dynamic> json) {
+    return BlogPost(
+      title: json['title'] as String,
+      excerpt: json['excerpt'] as String,
+      url: json['url'] as String,
+      imageUrl: json['imageUrl'] as String?,
+    );
+  }
+}
+
+class PaperDetail {
+  final String id;
+  final String title;
+  final List<String> authors;
+  final int year;
+  final List<String> fields;
+  final String abstractText;
+  final String translatedAbstract;
+  final String blogSummary;
+  final String pdfUrl;
+  final List<BlogPost> relatedBlogs;
+
+  PaperDetail({
+    required this.id,
+    required this.title,
+    required this.authors,
+    required this.year,
+    required this.fields,
+    required this.abstractText,
+    required this.blogSummary,
+    required this.pdfUrl,
+    required this.translatedAbstract,
+    this.relatedBlogs = const [],
+  });
+
+  factory PaperDetail.fromJson(Map<String, dynamic> json) {
+    return PaperDetail(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      authors: List<String>.from(json['authors'] as List<dynamic>),
+      year: json['year'] as int,
+      fields: List<String>.from(json['fields'] as List<dynamic>),
+      abstractText: json['abstractText'] as String,
+      blogSummary: json['blogSummary'] as String,
+      pdfUrl: json['pdfUrl'] as String,
+      translatedAbstract: json['translatedAbstract'] as String,
+      relatedBlogs:
+          (json['relatedBlogs'] as List<dynamic>?)
+              ?.map((e) => BlogPost.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+    );
+  }
+}

--- a/lib/features/dashboard/widgets/recommend_paper_card.dart
+++ b/lib/features/dashboard/widgets/recommend_paper_card.dart
@@ -7,62 +7,66 @@ class RecommendPaperCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.symmetric(vertical: 8),
-      color: Theme.of(context).cardColor,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          children: [
-            //좌측: 텍스트 영역
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  //추천 이유 (작은 회색 텍스트)
-                  Text(
-                    paper.recommendationReason,
-                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                      color: Theme.of(context).hintColor,
+    return InkWell(
+      onTap: () =>
+          Navigator.of(context).pushNamed('/paper', arguments: paper.id),
+      child: Card(
+        margin: const EdgeInsets.symmetric(vertical: 8),
+        color: Theme.of(context).cardColor,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              //좌측: 텍스트 영역
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    //추천 이유 (작은 회색 텍스트)
+                    Text(
+                      paper.recommendationReason,
+                      style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                        color: Theme.of(context).hintColor,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 4),
-                  // 논문 제목
-                  Text(
-                    paper.title,
-                    style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      fontWeight: FontWeight.bold,
+                    const SizedBox(height: 4),
+                    // 논문 제목
+                    Text(
+                      paper.title,
+                      style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  // 논문 요약
-                  Text(
-                    paper.summary,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context).textTheme.bodyMedium,
-                  ),
-                ],
+                    const SizedBox(height: 8),
+                    // 논문 요약
+                    Text(
+                      paper.summary,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ],
+                ),
               ),
-            ),
-            const SizedBox(width: 16),
-            //우측: 이미지 영역
-            ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: Image.network(
-                paper.imageUrl,
-                width: 100,
-                height: 100,
-                fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => Image.asset(
-                  'assets/images/default_paper_image.png',
+              const SizedBox(width: 16),
+              //우측: 이미지 영역
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Image.network(
+                  paper.imageUrl,
                   width: 100,
                   height: 100,
                   fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) => Image.asset(
+                    'assets/images/default_paper_image.png',
+                    width: 100,
+                    height: 100,
+                    fit: BoxFit.cover,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/paper/service/paper_service.dart
+++ b/lib/features/paper/service/paper_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../../../core/models/paper_detail_model.dart';
+
+class PaperService {
+  final String baseUrl = 'https://your-server.com/api';
+
+  Future<PaperDetail> fetchDetail(String paperId) async {
+    final uri = Uri.parse('$baseUrl/papers/$paperId');
+    final response = await http.get(uri);
+
+    if (response.statusCode != 200) {
+      throw Exception('논문 상세 조회 실패: HTTP ${response.statusCode}');
+    }
+
+    final Map<String, dynamic> data = json.decode(response.body);
+    return PaperDetail.fromJson(data);
+  }
+}

--- a/lib/features/paper/view/paper_detail_page.dart
+++ b/lib/features/paper/view/paper_detail_page.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../dashboard/widgets/header_widget.dart';
+import '../../dashboard/widgets/sidebar_widget.dart';
+import '../../dashboard/viewmodel/dashboard_viewmodel.dart';
+import '../viewmodel/paper_detail_viewmodel.dart';
+import '../widgets/blog_post_card.dart';
+import '../widgets/recommended_papers_list.dart';
+
+class PaperDetailPage extends StatefulWidget {
+  final String paperId;
+  const PaperDetailPage({Key? key, required this.paperId}) : super(key: key);
+
+  @override
+  _PaperDetailedPageState createState() => _PaperDetailedPageState();
+}
+
+class _PaperDetailedPageState extends State<PaperDetailPage>
+    with TickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<PaperDetailViewModel>().loadDetail(widget.paperId);
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<PaperDetailViewModel>();
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(80),
+        child: HeaderWidget(),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (context.watch<MainViewModel>().isSidebarOpen) SidebarWidget(),
+            VerticalDivider(
+              width: 1,
+              thickness: 1,
+              color: Theme.of(context).dividerColor,
+            ),
+            Expanded(
+              child: vm.isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : vm.error != null
+                  ? Center(child: Text('오류 발생: ${vm.error}'))
+                  : _buildContent(context, vm),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, PaperDetailViewModel vm) {
+    final detail = vm.detail;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pushNamed('/'),
+                child: const Text('Home'),
+              ),
+              const Text(' / '),
+              const Text(
+                'Paper Details',
+                style: TextStyle(fontWeight: FontWeight.w500),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            detail!.title,
+            style: Theme.of(
+              context,
+            ).textTheme.displayLarge?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Authors: ${detail.authors.join(', ')} | Published: ${detail.year} | Fields: ${detail.fields.join(', ')}',
+            style: Theme.of(context).textTheme.labelSmall,
+          ),
+
+          const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: () => _launchUrl(detail.pdfUrl),
+            icon: const Icon(Icons.download_rounded),
+            label: const Text('Download Paper'),
+          ),
+
+          const SizedBox(height: 24),
+          TabBar(
+            controller: _tabController,
+            labelColor: Theme.of(context).colorScheme.primary,
+            unselectedLabelColor: Theme.of(context).textTheme.bodyMedium?.color,
+            indicatorColor: Theme.of(context).colorScheme.primary,
+            tabs: const [
+              Tab(text: 'Abstract'),
+              Tab(text: 'Korean Translation'),
+              Tab(text: 'Blog Summary'),
+            ],
+          ),
+
+          SizedBox(
+            height: 300,
+            child: TabBarView(
+              children: [
+                SingleChildScrollView(
+                  padding: EdgeInsets.all(16),
+                  child: Text(detail.abstractText),
+                ),
+                SingleChildScrollView(
+                  padding: EdgeInsets.all(16),
+                  child: Text(detail.translatedAbstract),
+                ),
+                SingleChildScrollView(
+                  padding: EdgeInsets.all(16),
+                  child: Text(detail.blogSummary),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 32),
+          Text(
+            'Related Blog Posts',
+            style: Theme.of(
+              context,
+            ).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          ...detail.relatedBlogs.map((b) => BlogPostCard(blog: b)),
+
+          const SizedBox(height: 12),
+          RecommendedPapersList(),
+        ],
+      ),
+    );
+  }
+
+  void _launchUrl(String url) {
+    //url_luancher 로 구현
+  }
+}

--- a/lib/features/paper/viewmodel/paper_detail_viewmodel.dart
+++ b/lib/features/paper/viewmodel/paper_detail_viewmodel.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import '../../../core/models/paper_detail_model.dart';
+import '../service/paper_service.dart';
+
+class PaperDetailViewModel extends ChangeNotifier {
+  final PaperService _service = PaperService();
+
+  bool isLoading = false;
+  String? error;
+  PaperDetail? detail;
+
+  Future<void> loadDetail(String paperId) async {
+    isLoading = true;
+    error = null;
+    notifyListeners();
+
+    try {
+      detail = await _service.fetchDetail(paperId);
+    } catch (e) {
+      error = e.toString();
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/paper/widgets/blog_post_card.dart
+++ b/lib/features/paper/widgets/blog_post_card.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import '../../../core/models/paper_detail_model.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class BlogPostCard extends StatelessWidget {
+  final BlogPost blog;
+  const BlogPostCard({Key? key, required this.blog}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: InkWell(
+        onTap: () => launchUrl(Uri.parse(blog.url)),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Blog Post',
+                      style: Theme.of(context).textTheme.labelSmall,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      blog.title,
+                      style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      blog.excerpt,
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 8),
+                    TextButton(
+                      onPressed: () => launchUrl(Uri.parse(blog.url)),
+                      child: Text('Visit'),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Container(
+                width: 120,
+                height: 80,
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade300,
+                  borderRadius: BorderRadius.circular(6),
+                  image: blog.imageUrl != null
+                      ? DecorationImage(
+                          image: NetworkImage(blog.imageUrl!),
+                          fit: BoxFit.cover,
+                        )
+                      : null,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/paper/widgets/recommended_papers_list.dart
+++ b/lib/features/paper/widgets/recommended_papers_list.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import '../../../core/models/paper_model.dart';
+import '../../dashboard/widgets/recommend_paper_card.dart';
+
+class RecommendedPapersList extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final recs = Paper.sampleList();
+    return SizedBox(
+      height: 220,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        itemBuilder: (_, i) => RecommendPaperCard(paper: recs[i]),
+        separatorBuilder: (_, __) => const SizedBox(width: 16),
+        itemCount: recs.length,
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:paperlog_front/features/explore/view/explore_page.dart';
 import 'package:paperlog_front/features/explore/viewmodel/explore_viewmodel.dart';
+import 'package:paperlog_front/features/paper/view/paper_detail_page.dart';
+import 'package:paperlog_front/features/paper/viewmodel/paper_detail_viewmodel.dart';
 import 'package:provider/provider.dart';
 import 'features/dashboard/view/main_screen.dart';
 import 'shared/theme/app_theme.dart';
@@ -50,6 +52,14 @@ class PaperLogApp extends StatelessWidget {
           return ChangeNotifierProvider<ExploreViewmodel>(
             create: (_) => ExploreViewmodel()..search(initialQuery),
             child: ExplorePage(initialQuery: initialQuery),
+          );
+        },
+        '/paper': (context) {
+          final paperId =
+              ModalRoute.of(context)!.settings.arguments as String? ?? '';
+          return ChangeNotifierProvider(
+            create: (_) => PaperDetailViewModel()..loadDetail(paperId),
+            child: PaperDetailPage(paperId: paperId),
           );
         },
         //'/login': (context) => LoginPage(),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   http:
     dependency: "direct main"
     description:
@@ -163,6 +168,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   provider:
     dependency: "direct main"
     description:
@@ -232,6 +245,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.16"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   vector_math:
     dependency: transitive
     description:
@@ -248,6 +325,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
   provider: ^6.0.5
   http: ^0.13.5
+  url_launcher: ^6.1.12
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## 🔍 Key Changes

1. **Data Models**

   * **`core/models/paper_detail_model.dart`**

     * Defined `PaperDetail` (id, title, authors, year, fields, abstract, translation, summary, PDF URL, related blogs)
     * Defined `BlogPost` (title, excerpt, URL, optional imageUrl)
     * Added `fromJson` factories for decoding server responses

2. **Service Layer**

   * **`features/paper/service/paper_service.dart`**

     * Implemented `fetchDetail(paperId)` to call backend API
     * Parses JSON and throws on non-200 status codes

3. **ViewModel**

   * **`features/paper/viewmodel/paper_detail_viewmodel.dart`**

     * `PaperDetailViewModel` with `loadDetail(String paperId)`
     * Manages `isLoading`, `error`, and `detail` state

4. **UI: Paper Detail Page**

   * **`features/paper/view/paper_detail_page.dart`**

     * Converted to `StatefulWidget` with a 3‐tab `TabController`
     * Integrated `HeaderWidget` & `SidebarWidget` layout
     * Breadcrumb navigation (“Home / Paper Details”)
     * Title, authors, publication year, fields, and “Download PDF” button
     * **TabBar**: Abstract, Korean Translation, Blog Summary
     * **BlogPostCard** list for related blog posts
     * **RecommendedPapersList** horizontal scroll of recommended papers

5. **Reusable Widgets**

   * **`BlogPostCard`**: displays each related blog post with title, excerpt, “Visit” button, and optional thumbnail
   * **`RecommendedPapersList`**: horizontal list of `RecommendPaperCard` items

6. **Routing**

   * Registered `/paper` route in `main.dart`
   * Passes `paperId` via `Navigator.pushNamed('/paper', arguments: id)`
   * Wraps `PaperDetailPage` in `ChangeNotifierProvider<PaperDetailViewModel>`


